### PR TITLE
docs: expand README with setup, usage, and API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,204 @@
 # Alfred Workflow for Anybox
 
-Search links, save links, show Quick Save, toggle Anydock or do other things right in Alfred.
+Search links and notes, save the current browser tab or clipboard, browse lists,
+and toggle Anybox features — all from [Alfred](https://www.alfredapp.com), without
+leaving the keyboard.
 
 ![Search Links](./screenshots/1.png)
 
 ![Search Links](./screenshots/2.png)
 
-## Supported Version
+This workflow is a thin bridge between Alfred and the **local HTTP API** that
+[Anybox](https://anybox.app) exposes on port `6391`. Each Alfred command runs a
+small Python 3 or shell script that calls the API and renders the result as an
+Alfred list. Anybox must be running for the workflow to work.
 
-This workflow is developed and tested with Anybox 2.0 and Alfred 5.
+## Requirements
 
-## Install
+- **Anybox 2.0+** (running, with its local API enabled)
+- **Alfred 5** with the Powerpack (workflows require the paid Powerpack)
+- **Python 3** at `/usr/bin/python3` — pre-installed on macOS. No third-party
+  Python packages are required; scripts use only the standard library.
 
-1. Download [Anybox.alfredworkflow](https://github.com/anyboxhq/anybox-alfred-workflow/raw/main/Anybox.alfredworkflow) and install.
+## Installation
 
-2. Go to “Anybox › Settings › General” to copy API key.
+1. Download [`Anybox.alfredworkflow`](https://github.com/anyboxhq/anybox-alfred-workflow/raw/main/Anybox.alfredworkflow)
+   and double-click it to install into Alfred.
+2. In Anybox, go to **Settings → General** and copy your **API key**.
+3. In Alfred, go to **Workflows → Anybox → Configure Workflow…** (the `[𝓍]` button)
+   and paste the API key. Adjust the other options if desired (see
+   [Configuration](#configuration)).
+4. Trigger the search with the default keyword `sd␣` (space) followed by your query.
 
-3. Go to “Alfred › Workflows › Anybox › Configure Workflow” to enter API key.
+## Configuration
 
-4. Type in default keyword “sd[space]” to search links in Anybox.
+The workflow's behavior is driven by user-configurable variables set in
+**Configure Workflow…**. They are exported as environment variables to the scripts.
 
-For this workflow to work, Anybox needs to be running.
+- **`api_key`** — Your Anybox API key. Sent as the `x-api-key` header on
+  authenticated requests (search endpoints).
+- **`search_keyword`** — The keyword that triggers link search. Defaults to `sd`.
+- **`show_full_urls`** — Show the full URL instead of just the host in result
+  subtitles. (`checkbox` → `1`/`0`)
+- **`show_dates`** — Append the "last opened" date to result subtitles, formatted
+  as `Today at HH:MM`, `Yesterday at HH:MM`, `Mon DD, YYYY at HH:MM`, or `Mon DD, YYYY`.
+- **`show_tags`** — Interleave matching tags into link search results.
+- **`show_folders`** — Interleave matching folders into link search results.
 
-## Supported Actions
+> When both `show_tags` and `show_folders` are enabled, the per-container result
+> limit drops from 5 to 3 to keep the list readable.
 
-1. Search Links
+## Usage
 
-2. Search Notes
+Trigger any of the following keywords in Alfred.
 
-3. Show Quick Save
+### Search
 
-4. Save Current Tab
+- **`sd␣<query>`** (`search_keyword`) — Search links. Results show the favicon,
+  title, and a configurable subtitle. Selecting a tag or folder (when enabled)
+  drills into that container and searches links within it.
+- **`search notes␣<query>`** — Search note-type items. Subtitle shows character
+  count and, optionally, the date.
+- **`show list␣`** — Browse all Presets, Smart Lists, Tags, and Folders and open
+  the chosen one in Anybox.
 
-5. Save Current Tab with Tags
+**Result modifiers (search links / notes):**
 
-6. Save Current Tab to Folder
+- `⏎` — Open the link (or note text) / open the item.
+- `⌘ ⏎` — Use the `anybox://document/<id>` deep link (opens the item in Anybox).
+- `⌥ ⏎` — Copy a Markdown link `[title](url)`.
+- `⇧ ⏎` — Use the raw URL.
+- `⌘ C` — Copy the URL (notes copy their text).
+- Quick Look (`⇧`) previews the link URL.
 
-7. Save Clipboard
+### Save
 
-8. Save Clipboard with Tags
+- **`save current tab␣`** — Save the frontmost browser tab to Anybox.
+- **`save tab tags␣`** — Save the current tab, then pick tag(s) to apply.
+- **`save tab folder␣`** — Save the current tab into a chosen folder.
+- **`save clipboard␣`** — Save the clipboard contents.
+- **`save clipboard tag␣`** — Save the clipboard, then pick tag(s).
+- **`save clipboard folder␣`** — Save the clipboard into a chosen folder.
+- **`save note␣<text>`** — Save a new note with the given text.
 
-9. Save Clipboard to Folder
+### Toggles & AnyDock
 
-10. Save Note
+- **`show quick save␣`** — Show the Quick Save panel.
+- **`toggle anydock␣`** — Show/hide AnyDock.
+- **`toggle stash box␣`** — Show/hide the Stash Box.
+- **`toggle link detection␣`** — Enable/disable link detection.
+- **`switch profile␣`** — Switch to a selected AnyDock profile.
+- **`open all profile␣`** — Open all links in a selected AnyDock profile.
 
-11. Toggle Anydock
+## How it works
 
-12. Toggle Stash Box
+Every command shells out to a script under [`src/`](./src) that talks to Anybox's
+local API. Search-type commands are Alfred **Script Filters**: they print
+[Script Filter JSON](https://www.alfredapp.com/help/workflows/inputs/script-filter/json/)
+(`{"items": [...]}`) to stdout, which Alfred renders. Action-type commands issue a
+`POST`/`PUT` to trigger a side effect (save, toggle, switch).
 
-13. Toggle Link Detection
+Source scripts:
 
-14. Switch Anydock Profile
+- `search-links.py` — `sd` search; queries `/search`, downloads each result's
+  favicon locally into `./Link Icons/<id>/icon`, and optionally merges in matching
+  tags/folders.
+- `search-links-in-container.py` — Search scoped to a tag or folder (via the `id`
+  and `type` environment variables).
+- `search-notes.py` — Searches note items (`type=note`).
+- `savenote.py` — `POST /save` with a JSON `{ "note": ... }` body.
+- `show-list.py` — Aggregates `/presets`, `/filters`, `/tags`, `/folders` and maps
+  each to its `anybox://` URL scheme.
+- `select-folder.py` / `select-tag.py` — Folder/tag pickers used by the
+  save-to-folder / save-with-tags flows.
+- `anydock-profiles.py` — Lists AnyDock profiles for the switch/open-all commands.
 
-15. Open All in Anydock Profile
+## API interaction
 
-16. Show List
+All requests target the local Anybox server on port **`6391`**. Search/read
+endpoints require the `x-api-key` header (set from `api_key`).
 
-![Search Links](./screenshots/3.png)
+### Read (GET)
 
-## Feature Requests or Bug Reports
+- `GET /search?q=<query>&limit=<n>` — Search links. Optional parameters:
+  - `type=note` — restrict to notes.
+  - `tag=<id>` — restrict to a tag.
+  - `folder=<id>` — restrict to a folder.
+- `GET /tags` — List tags.
+- `GET /folders` — List folders.
+- `GET /presets` — List presets.
+- `GET /filters` — List Smart Lists.
+- `GET /anydock-profiles` — List AnyDock profiles.
+- `GET /images/<id>/icon` — Favicon for a link (cached locally by the workflow).
 
-Open an issue.
+A search result object includes fields such as `id`, `title`, `url`, `host`,
+`comment`, `dateLastOpened`, and (for notes) `description`.
 
-## Trouble Shooting
+### Write (POST / PUT)
 
-### “Search Links” Action Not Working
+- `POST /save` — Save a note. JSON body `{ "note": "<text>" }`.
+- `POST /save-current-tab` — Save the frontmost browser tab.
+- `POST /paste` — Save clipboard contents.
+- `PUT  /document/<id>` — Associate a just-saved item with a folder/tag
+  (used by the save-to-folder / save-with-tags flows).
+- `POST /show-quick-save` — Show the Quick Save panel.
+- `POST /toggle-anydock` — Toggle AnyDock.
+- `POST /toggle-stashbox` — Toggle the Stash Box.
+- `POST /toggle-link-detection` — Toggle link detection.
+- `POST /switch-profile/<id>` — Switch AnyDock profile.
+- `POST /open-all-in-profile/<id>` — Open all links in an AnyDock profile.
 
-Anybox workflow doesn’t require any third-party dependencies. These actions are developed with shell script and Python 3, which are pre-installed on macOS.
+### `anybox://` URL scheme
 
-However, in some cases the Python 3 on your Mac maybe not working properly.
+Results also expose deep links used as action arguments:
 
-So you need to make sure your Mac have a valid Python 3 at `/usr/bin/python3`. To verify, open Termimal.app and type in `/usr/bin/python3`. A valid output should look like this:
+- `anybox://show` — Open Anybox.
+- `anybox://show?id=<id>` — Open a preset.
+- `anybox://document/<id>` — Open a specific document (link/note).
+- `anybox://tag/<id>`, `anybox://folder/<id>`, `anybox://filter/<id>` — Open a
+  tag, folder, or Smart List.
+
+### Error handling
+
+If Anybox is not running (connection refused → `URLError`) or returns an error
+(`HTTPError`), the scripts emit a friendly Alfred item explaining the problem and
+offering to open Anybox (`anybox://show`) or install it from the Mac App Store.
+
+## Troubleshooting
+
+### "Search Links" action not working
+
+The scripts rely on a working Python 3 at `/usr/bin/python3`. Verify it in
+Terminal:
 
 ```
-Python 3.9.6 (default, Oct 18 2022, 12:41:40) 
+/usr/bin/python3
+```
+
+A healthy install prints something like:
+
+```
+Python 3.9.6 (default, Oct 18 2022, 12:41:40)
 [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
 Type "help", "copyright", "credits" or "license" for more information.
->>> 
+>>>
 ```
 
-If your terminal’s output looks like this:
+If you instead see:
+
 ```
-xcrun: error: invalid active developer path (/Library/Developer/commandLineTools), missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun
+xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun
 ```
 
-You can fix this with the following instruction from Stack Exchange: [Why am I getting an “invalid active developer path” when attempting to use Git after upgrading to macOS Ventura?](https://apple.stackexchange.com/questions/254380/why-am-i-getting-an-invalid-active-developer-path-when-attempting-to-use-git-a/254381#254381)
+follow this fix: [Why am I getting an "invalid active developer path"…](https://apple.stackexchange.com/questions/254380/why-am-i-getting-an-invalid-active-developer-path-when-attempting-to-use-git-a/254381#254381).
+
+Also confirm that Anybox is running and that the API key in **Configure Workflow…**
+matches the one in **Anybox → Settings → General**.
+
+## Supported versions
+
+Developed and tested with **Anybox 2.0** and **Alfred 5**.
+
+## Feature requests or bug reports
+
+Open an issue on the [repository](https://github.com/anyboxhq/anybox-alfred-workflow).

--- a/src/savenote.py
+++ b/src/savenote.py
@@ -2,6 +2,7 @@ from urllib import request
 import urllib.error
 import json
 import sys
+import os
 
 note = ''
 if len(sys.argv) >= 2:
@@ -11,13 +12,14 @@ payload = {
 	'note': note
 }
 data = json.dumps(payload).encode("utf-8")
-headers = {'Content-Type': 'application/json'}
+api_key = os.getenv('api_key')
+headers = {'Content-Type': 'application/json', 'x-api-key': api_key}
 req = request.Request('http://127.0.0.1:6391/save', headers=headers, data=data, method='POST')
 
 error_feedback = {
   'items': [
     {
-      'title': 'It looks like Anybox it’s not running or haven’t installed.',
+      'title': 'It looks like Anybox is not running or hasn’t been installed.',
       'subtitle': 'Press ⏎ to open Anybox or press ⌘ + ⏎ to install Anybox in Mac App Store.',
       'arg': ['anybox://show'],
       'mods': {
@@ -34,6 +36,6 @@ error_feedback = {
 try:
     request.urlopen(req)
 except urllib.error.HTTPError as e:
-    sys.stdout.write(error_feedback)
+    sys.stdout.write(json.dumps(error_feedback))
 except urllib.error.URLError as e:
-    sys.stdout.write(error_feedback)
+    sys.stdout.write(json.dumps(error_feedback))

--- a/src/search-links-in-container.py
+++ b/src/search-links-in-container.py
@@ -53,7 +53,7 @@ def format_date(original):
     if is_today(date):
         return 'Today at ' + date.astimezone(tz).strftime("%H:%M")
     elif is_yesteryday(date):
-        return 'Yesterady at ' + date.astimezone(tz).strftime("%H:%M")
+        return 'Yesterday at ' + date.astimezone(tz).strftime("%H:%M")
     elif less_than_a_week(date):
         return date.astimezone(tz).strftime("%b %d, %Y at %H:%M")
     return date.astimezone(tz).strftime("%b %d, %Y")
@@ -89,7 +89,7 @@ def throw_error():
   error_feedback = {
     'items': [
       {
-        'title': 'It looks like Anybox it’s not running or haven’t installed.',
+        'title': 'It looks like Anybox is not running or hasn’t been installed.',
         'subtitle': 'Press ⏎ to open Anybox or press ⌘ + ⏎ to install Anybox in Mac App Store.',
         'arg': ['anybox://show'],
         'mods': {
@@ -103,6 +103,7 @@ def throw_error():
     ]
   }
   sys.stdout.write(json.dumps(error_feedback))
+  sys.exit(0)
 
 def get_links():
   headers = {'x-api-key': api_key}

--- a/src/search-links.py
+++ b/src/search-links.py
@@ -48,7 +48,7 @@ def format_url(url):
     if url.startswith('https://'):
         return remove_prefix(url, 'https://')
     elif url.startswith('http://'):
-        return url.remove_prefix(url, 'http://')
+        return remove_prefix(url, 'http://')
     else:
         return url
 
@@ -59,7 +59,7 @@ def format_date(original):
     if is_today(date):
         return 'Today at ' + date.astimezone(tz).strftime("%H:%M")
     elif is_yesteryday(date):
-        return 'Yesterady at ' + date.astimezone(tz).strftime("%H:%M")
+        return 'Yesterday at ' + date.astimezone(tz).strftime("%H:%M")
     elif less_than_a_week(date):
         return date.astimezone(tz).strftime("%b %d, %Y at %H:%M")
     return date.astimezone(tz).strftime("%b %d, %Y")
@@ -95,7 +95,7 @@ def throw_error():
   error_feedback = {
     'items': [
       {
-        'title': 'It looks like Anybox it’s not running or haven’t installed.',
+        'title': 'It looks like Anybox is not running or hasn’t been installed.',
         'subtitle': 'Press ⏎ to open Anybox or press ⌘ + ⏎ to install Anybox in Mac App Store.',
         'arg': ['anybox://show'],
         'mods': {
@@ -109,6 +109,7 @@ def throw_error():
     ]
   }
   sys.stdout.write(json.dumps(error_feedback))
+  sys.exit(0)
 
 def get_links():
   headers = {'x-api-key': api_key}

--- a/src/search-notes.py
+++ b/src/search-notes.py
@@ -45,7 +45,7 @@ def format_date(original):
     if is_today(date):
         return 'Today at ' + date.astimezone(tz).strftime("%H:%M")
     elif is_yesteryday(date):
-        return 'Yesterady at ' + date.astimezone(tz).strftime("%H:%M")
+        return 'Yesterday at ' + date.astimezone(tz).strftime("%H:%M")
     elif less_than_a_week(date):
         return date.astimezone(tz).strftime("%b %d, %Y at %H:%M")
     return date.astimezone(tz).strftime("%b %d, %Y")
@@ -66,7 +66,7 @@ def throw_error():
   error_feedback = {
     'items': [
       {
-        'title': 'It looks like Anybox it’s not running or haven’t installed.',
+        'title': 'It looks like Anybox is not running or hasn’t been installed.',
         'subtitle': 'Press ⏎ to open Anybox or press ⌘ + ⏎ to install Anybox in Mac App Store.',
         'arg': ['anybox://show'],
         'mods': {
@@ -80,6 +80,7 @@ def throw_error():
     ]
   }
   sys.stdout.write(json.dumps(error_feedback))
+  sys.exit(0)
 
 def get_notes():
   headers = {'x-api-key': api_key}

--- a/src/select-folder.py
+++ b/src/select-folder.py
@@ -6,7 +6,7 @@ import json
 error_feedback = {
   'items': [
     {
-      'title': 'It looks like Anybox it’s not running or haven’t installed.',
+      'title': 'It looks like Anybox is not running or hasn’t been installed.',
       'subtitle': 'Press ⏎ to open Anybox or press ⌘ + ⏎ to install Anybox in Mac App Store.',
       'arg': ['anybox://show'],
       'mods': {

--- a/src/select-tag.py
+++ b/src/select-tag.py
@@ -6,7 +6,7 @@ import json
 error_feedback = {
   'items': [
     {
-      'title': 'It looks like Anybox it’s not running or haven’t installed.',
+      'title': 'It looks like Anybox is not running or hasn’t been installed.',
       'subtitle': 'Press ⏎ to open Anybox or press ⌘ + ⏎ to install Anybox in Mac App Store.',
       'arg': ['anybox://show'],
       'mods': {


### PR DESCRIPTION
## Summary
Expands the README into comprehensive documentation for the workflow, verified against the source scripts in `src/` and the packaged `info.plist`.

Adds:
- **Requirements & Installation** — Anybox 2.0+, Alfred 5 Powerpack, `/usr/bin/python3`, and step-by-step setup.
- **Configuration** — all six user config variables (`api_key`, `search_keyword`, `show_full_urls`, `show_dates`, `show_tags`, `show_folders`).
- **Usage** — every keyword grouped into Search / Save / Toggles & AnyDock, plus result modifier keys.
- **How it works** — Script Filter vs. action pattern with a per-script reference.
- **API interaction** — full local endpoint reference on port `6391` (GET + POST/PUT), the `x-api-key` header, the `anybox://` URL scheme, and error handling.
- **Troubleshooting** and supported versions.

Co-Authored-By: Oz <oz-agent@warp.dev>